### PR TITLE
Add obsidian-note skill and tidy outstanding skills

### DIFF
--- a/claude/skills/address-pr-comments/SKILL.md
+++ b/claude/skills/address-pr-comments/SKILL.md
@@ -5,97 +5,45 @@ description: Fetch and respond to GitHub PR comments. Use when asked to get PR f
 
 # Addressing PR Comments
 
-## Setup
+## Fetching Comments
 
-Define your target PRs as variables:
+### Get review comments (inline code comments)
 
 ```bash
-OWNER="travelperk"
-REPO="terraform-aws"
-PR_NUMBERS=(15374 15375 15376 15377 15378 15379)  # Or pass as argument
+gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments
+```
 
-Step 1: Fetch Comments from a PR
+### Get review summaries (approvals, rejections, change requests)
 
-# Get all comments (including review comments on code)
-gh api repos/$OWNER/$REPO/pulls/{PR_NUMBER}/comments \
-  --template='{{range .}}{{printf "ID: %d | Author: %s | Resolved: %v\n" .id .user.login .resolved}}{{printf "Line %d:
-%s\n\n" .line .body}}{{end}}'
+```bash
+gh pr view {PR_NUMBER} --repo {OWNER}/{REPO} --json reviews,comments
+```
 
-# Get review summaries (approvals, rejections, change requests)
-gh pr view {PR_NUMBER} --json reviews \
-  --template='{{range .reviews}}{{printf "%s - %s\n" .author.login .state}}{{end}}'
+## Filtering Comments
 
-Step 2: Filter Comments (apply these rules)
+Skip:
+- Bot authors (copilot-pull-request-reviewer, github-actions, etc.)
+- Comments marked as resolved
+- Comments already addressed in later commits
 
-Skip entirely:
-- Authors: tk-elbot-2-0, atlantis-bot, github-copilot
-- Marked as .resolved: true
-- Contextually addressed in later commits
-
-Include for response:
-- Unresolved comments from humans (.resolved: false)
+Include:
+- Unresolved comments from humans
 - Review state: COMMENTED or CHANGES_REQUESTED
-- unblocked-bot findings with human validation
 
-Step 3: Reply to a Comment
+## Replying to Comments
 
-# Get the comment ID from Step 1, then reply:
-COMMENT_ID=2833726406
-gh api repos/$OWNER/$REPO/pulls/comments/$COMMENT_ID/replies \
-  -f body="Brief explanation of how this was addressed or why it's not needed.
+**IMPORTANT**: The reply API requires the PR number in the path:
 
-— AI agent"
+```bash
+gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments/{COMMENT_ID}/replies \
+  -f body="Explanation of how this was addressed."
+```
 
-# Verify the reply was posted:
-gh api repos/$OWNER/$REPO/pulls/comments/$COMMENT_ID \
-  --template='{{.body}}'
+The comment ID comes from the `id` field in the comments response.
 
-Batch Processing Multiple PRs
+Sign off replies with `-Claude`.
 
-# Check all PRs for unresolved human comments
-for pr in "${PR_NUMBERS[@]}"; do
-  echo "=== PR $pr ==="
+## Response Style
 
-  # Fetch and display comments
-  gh api repos/$OWNER/$REPO/pulls/$pr/comments \
-    --template='{{range .}}{{if and (ne .user.login "tk-elbot-2-0") (not .resolved)}}Comment {{.id}} by {{.user.login}}:
- {{.body}}{{"\n"}}{{end}}{{end}}'
-done
-
-Response Template
-
-When replying to addressed comments:
-
-<Concise explanation of the fix or clarification>
-
-Example:
-The [0] indexing is required because the new modules have count = var.create_new_invoice_collection_lambdas ? 1 : 0
-applied to them. In Terraform, when count is used, resources must be referenced with [0] indexing to access the first
-instance.
-
-— AI agent
-
-Troubleshooting
-
-"Comment not found" error:
-- Verify comment ID is correct: gh api repos/$OWNER/$REPO/pulls/comments/$ID
-- Check PR number matches the comment's PR
-
-Can't fetch comments:
-- Ensure you have GitHub CLI installed: gh --version
-- Check authentication: gh auth status
-- Verify API access: gh api repos/$OWNER/$REPO
-
-jq issues with filtering:
-- Use --template instead of piping to jq (avoids escaping issues)
-- Or use simple grep for basic filtering if template fails
-
-Common Patterns
-
-Get comments by a specific person:
-gh api repos/$OWNER/$REPO/pulls/{PR}/comments \
-  --template='{{range .}}{{if eq .user.login "username"}}ID: {{.id}} | {{.body}}{{"\n"}}{{end}}{{end}}'
-
-Verify all replies were posted:
-gh api repos/$OWNER/$REPO/pulls/{PR}/comments \
-  --template='{{range .}}{{if contains .body "AI agent"}}✓ {{.id}}{{"\n"}}{{end}}{{end}}'
+Keep replies concise. Briefly explain what was changed or why the suggestion
+wasn't needed. Don't repeat the reviewer's comment back to them.

--- a/claude/skills/obsidian-note/SKILL.md
+++ b/claude/skills/obsidian-note/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: obsidian-note
+description: Create a new note in the Obsidian vault. Use when asked to create a note, write something down, or save information to Obsidian.
+---
+
+# Create Obsidian Note
+
+## Vault location
+
+Notes live in `$VAULTS_PATH` (currently `/home/iainmclaughlan/notes/hitchhiker/`).
+New notes go in the `inbox/` directory.
+
+## File naming
+
+Convert the note title to a filename by replacing spaces with underscores and
+appending `.md`:
+
+```
+"My Great Note" → My_Great_Note.md
+```
+
+## Choose the right template
+
+Read the templates in `$VAULTS_PATH/templates/` and pick the best match based
+on what the user wants to write about:
+
+| Template | When to use |
+|---|---|
+| `note.md` | General notes, default if nothing else fits |
+| `daily.md` | Daily journal / reflection |
+| `code_snip.md` | Code snippet for personal projects |
+| `code_travelperk.md` | Code snippet related to TravelPerk work |
+| `acronyms.md` | Definition of an acronym |
+| `project_summary.md` | Summary of a project (outcomes, challenges, feedback) |
+| `travelperk.md` | General TravelPerk work note |
+| `walk_report.md` | Hill walking / munro report |
+
+## Fill in the template
+
+Replace all `{{placeholder}}` values in the chosen template:
+
+- `{{title}}` — the note title
+- `{{date}}` — today's date in `YYYY-MM-DD` format
+- `{{language}}` — programming language (code templates)
+- `{{description}}`, `{{meaning}}`, `{{notes}}` — generate from context
+
+### Required frontmatter: `hub` and `aliases`
+
+Every note **must** have `hub` and `aliases` set correctly in the YAML
+frontmatter. These are how Obsidian organises and cross-links notes.
+
+- **`hub`** — determines which section the note is sorted into. Each template
+  has a default hub (e.g. `dailies`, `hills`, `travelperk`, `notes`). For code
+  templates the hub is the programming language name.
+- **`aliases`** — alternative names used for linking to the note with `[[...]]`.
+  Always include at least the note title as an alias. For daily notes also add
+  the human-readable date and ISO date string.
+
+Example frontmatter:
+```yaml
+---
+title: "My Great Note"
+date: "2026-03-01"
+aliases:
+  - My Great Note
+hub: notes
+tags:
+  - note
+---
+```
+
+Fill in the body sections using the current conversation context. Write in the
+user's voice — concise, factual, no fluff.
+
+## Create the file
+
+Write the completed note to `$VAULTS_PATH/inbox/{filename}`.
+
+Tell the user the full path so they can open it.

--- a/claude/skills/worktree-testing/SKILL.md
+++ b/claude/skills/worktree-testing/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: worktree-testing
+description: Guide for testing changes locally when working in a Claude Code worktree. Use when running dev servers, tests, or verifying changes in a worktree.
+---
+
+# Testing in Claude Code Worktrees
+
+Worktrees (`claude -w <name>`) create an isolated copy of the repo at
+`.claude/worktrees/<name>/` on a new branch `worktree-<name>`.
+
+## Setup
+
+Dependencies are not pre-installed in a new worktree. Install them before
+running anything:
+
+```bash
+# Frontend
+cd frontend && npm install
+
+# Backend
+cd backend && pip install -e ".[dev]"
+```
+
+## Running dev servers
+
+Run `just run` or individual dev commands as normal — the worktree is a full
+working copy.
+
+**Port conflicts**: If the main repo is already running dev servers, the
+worktree will fail to bind the same ports. Stop the main instance first or
+configure different ports.
+
+## Testing from a separate terminal
+
+Open another terminal and `cd` into the worktree directory to run servers,
+curl endpoints, or open the browser while Claude works in the session:
+
+```bash
+cd .claude/worktrees/<name>/
+just run
+```
+
+## Cleanup
+
+When exiting the Claude session:
+- **No changes made**: worktree and branch are deleted automatically
+- **Changes made**: Claude prompts whether to keep or remove the worktree


### PR DESCRIPTION
## Summary

- Added `obsidian-note` skill for creating notes in the Obsidian vault — picks the right template, fills placeholders, and ensures `hub` and `aliases` frontmatter are set correctly
- Simplified `address-pr-comments` skill — replaced hardcoded repo values and verbose bash with cleaner `gh api` commands
- Added `worktree-testing` skill for verifying changes in Claude Code worktrees