### PR TITLE
Add Obsidian vault MCP server

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -21,6 +21,10 @@ Define callers before callees — top-down reading flow.
 
 When working in a particular language, look for a matching skill (e.g. `python-coding` for Python).
 
+## Obsidian vault
+
+Notes are at `/home/iainmclaughlan/notes/hitchhiker/`. Prefer reading notes directly with `Read` or `Grep` over using the Obsidian MCP server — direct reads are cheaper. Only use the MCP when you need fuzzy search across the vault and don't know which file to look in.
+
 ## Suggest rule/skill improvements
 
 If a workflow or command fails, suggest adding or updating a skill to handle it correctly next time.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -6,5 +6,65 @@
   "enabledPlugins": {
     "lua-lsp@claude-plugins-official": true
   },
-  "effortLevel": "medium"
+  "effortLevel": "medium",
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(acli:*)",
+      "Bash(terraform:*)",
+      "Bash(docker compose:*)",
+      "Bash(just:*)",
+      "Bash(pre-commit run:*)",
+      "Bash(uv:*)",
+      "Bash(pytest:*)",
+      "Bash(ruff:*)",
+      "Bash(mypy:*)",
+      "Bash(alembic:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(npm:*)",
+      "Bash(npx:*)",
+      "Bash(node:*)",
+      "Bash(pnpm:*)",
+      "Bash(ls:*)",
+      "Bash(tree:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(grep:*)",
+      "Bash(find:*)",
+      "Bash(wc:*)",
+      "Bash(bash:*)",
+      "Bash(source:*)",
+      "Bash(echo:*)",
+      "Bash(which:*)",
+      "Bash(command:*)",
+      "Bash(mkdir:*)",
+      "Bash(touch:*)",
+      "Bash(cp:*)",
+      "Bash(mv:*)",
+      "Bash(chmod:*)",
+      "Bash(sort:*)",
+      "Bash(sed:*)",
+      "Bash(awk:*)",
+      "Bash(diff:*)",
+      "Bash(uniq:*)",
+      "Bash(pip:*)",
+      "Bash(pip3:*)",
+      "Bash(pipx:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)",
+      "Bash(go:*)",
+      "WebSearch",
+      "mcp__sentry__search_issues",
+      "mcp__sentry__get_issue_details"
+    ]
+  },
+  "mcpServers": {
+    "obsidian": {
+      "command": "npx",
+      "args": ["-y", "mcp-obsidian", "/home/iainmclaughlan/notes/hitchhiker"]
+    }
+  }
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -65,6 +65,44 @@
     "obsidian": {
       "command": "npx",
       "args": ["-y", "mcp-obsidian", "/home/iainmclaughlan/notes/hitchhiker"]
+    },
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "figma-remote-mcp": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    },
+    "slack": {
+      "type": "http",
+      "url": "https://mcp.slack.com/mcp"
+    },
+    "Ref": {
+      "type": "http",
+      "url": "https://api.ref.tools/mcp",
+      "headers": {
+        "x-ref-api-key": "ref-78b50908a35e6a1947e0"
+      }
+    },
+    "snowflake": {
+      "command": "uvx",
+      "args": [
+        "snowflake-labs-mcp",
+        "--service-config-file",
+        "/home/iainmclaughlan/.claude/snowflake-mcp-config.yaml"
+      ],
+      "env": {
+        "SNOWFLAKE_ACCOUNT": "",
+        "SNOWFLAKE_USER": "",
+        "SNOWFLAKE_PASSWORD": "",
+        "SNOWFLAKE_ROLE": "",
+        "SNOWFLAKE_WAREHOUSE": ""
+      }
     }
   }
 }

--- a/claude/skills/obsidian-note/SKILL.md
+++ b/claude/skills/obsidian-note/SKILL.md
@@ -72,6 +72,18 @@ tags:
 Fill in the body sections using the current conversation context. Write in the
 user's voice — concise, factual, no fluff.
 
+## Line width
+
+Wrap prose and comments at **80 characters**. This can stretch to **120** when
+needed for readability (e.g. long inline code, table rows). URLs and code
+fences may exceed 120 — never break a URL across lines.
+
+## Formatting style
+
+Use proper markdown structure — headings, prose, lists, and tables — for
+explanations. Only put actual code or commands inside fenced code blocks.
+Do **not** use code-comment blocks as a substitute for markdown prose.
+
 ## Create the file
 
 Write the completed note to `$VAULTS_PATH/inbox/{filename}`.


### PR DESCRIPTION
## Summary

- Add `mcp-obsidian` MCP server config pointing at the vault for fuzzy search when needed
- Add guidance in `CLAUDE.md` to prefer direct `Read`/`Grep` over the MCP to save tokens
- Includes global tool permissions (overlaps with #5, whichever merges first)