### PR TITLE
Add code-review, research, and review-pr skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Personal dotfiles repository for a WSL Ubuntu development environment, primarily
   - `wezterm/config/` — Appearance, keybindings, init
   - `wezterm/utils/` — Platform detection utilities
 - `claude/` — Claude Code configuration (skills, settings)
-  - `claude/skills/` — Custom skills (commit-code, create-draft-pr, address-pr-comments, python-coding, jira-cli, worktree-testing)
+  - `claude/skills/` — Custom skills (commit-code, create-draft-pr, address-pr-comments, code-review, review-pr, research, python-coding, jira-cli, worktree-testing)
 - `zsh/` — Zsh config (`.zshrc`) and helper scripts in `zsh/bin/`
 - `fish/` — Fish shell config
 - `tmux/` — Tmux configuration

--- a/claude/skills/code-review/SKILL.md
+++ b/claude/skills/code-review/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: code-review
+description: Review code for bugs, style, and design issues. Use when asked to review a PR, review local changes, or do a code review.
+---
+
+# Code Review
+
+Review code changes and provide actionable feedback on bugs, design, clarity,
+and style. Supports two modes: GitHub PR review and local diff review.
+
+## Determine the review target
+
+- If given a PR number or URL, use **PR review mode**.
+- If no PR is specified, use **local diff review mode** (staged + unstaged changes).
+
+---
+
+## PR Review Mode
+
+### Fetch the diff
+
+```bash
+gh pr diff {PR_NUMBER}
+```
+
+Get PR context (description, linked issues):
+
+```bash
+gh pr view {PR_NUMBER} --json title,body,labels,baseRefName,headRefName
+```
+
+### Read changed files in full
+
+Don't review the diff in isolation. For each significantly changed file, read
+the full file to understand the surrounding context before commenting.
+
+### Leave review comments
+
+For issues found, leave inline comments on the PR:
+
+```bash
+gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/reviews \
+  -f event="COMMENT" \
+  -f body="Overall review summary" \
+  --jsonArray comments='[{"path":"file.py","line":42,"body":"Issue description"}]'
+```
+
+For minor or nitpick items, prefix the comment body with `nit:`.
+
+Sign off every comment with `-Claude`.
+
+---
+
+## Local Diff Review Mode
+
+### Gather the diff
+
+```bash
+git diff
+git diff --staged
+```
+
+If both are empty, check for unpushed commits against the base branch:
+
+```bash
+git log --oneline origin/main..HEAD
+git diff origin/main..HEAD
+```
+
+### Read changed files in full
+
+Same as PR mode — read surrounding context before commenting.
+
+### Present findings
+
+Print findings grouped by file. For each issue, include:
+
+- **File and line** — `path/to/file.py:42`
+- **Severity** — bug, design, clarity, style, nit
+- **Description** — what's wrong and a suggested fix
+
+---
+
+## What to look for
+
+Focus on issues that matter. In priority order:
+
+1. **Bugs** — logic errors, off-by-ones, null/None handling, race conditions
+2. **Security** — injection, auth gaps, secrets in code, OWASP top 10
+3. **Design** — wrong abstraction, tight coupling, violation of existing patterns
+4. **Edge cases** — missing error handling at system boundaries, unhandled states
+5. **Clarity** — misleading names, unnecessary complexity, missing *why* comments
+6. **Style** — only flag if inconsistent with the surrounding codebase
+
+## What to skip
+
+- Don't flag formatting issues handled by linters/formatters.
+- Don't suggest adding docstrings, type hints, or comments to unchanged code.
+- Don't suggest renaming things that follow the project's existing conventions.
+- Don't request tests unless the change is clearly untested and risky.
+- Don't repeat what the diff already makes obvious.
+
+## Tone
+
+Be direct and constructive. State the issue, explain why it matters, suggest a
+fix. No filler, no praise sandwiches.

--- a/claude/skills/research/SKILL.md
+++ b/claude/skills/research/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: research
+description: Research a topic by exploring the codebase and external documentation. Use when asked to investigate how something works, find usage patterns, or look up library/API docs.
+---
+
+# Research
+
+Investigate a question by combining codebase exploration with external
+documentation lookups. Return a concise, structured answer — not a dump of
+everything found.
+
+## Clarify the question
+
+Before diving in, make sure the research goal is specific. If the user's
+question is vague, ask one clarifying question to narrow scope. Good research
+has a clear deliverable: an answer, a recommendation, or a summary.
+
+## Codebase exploration
+
+### Trace from entry points
+
+Start from known entry points (routes, CLI commands, main functions) and follow
+the call chain. Don't grep randomly — work top-down.
+
+### Find patterns and conventions
+
+```bash
+# Find all implementations of a pattern
+grep -r "pattern" --include="*.py" -l
+# Find where something is imported/used
+grep -r "from module import" --include="*.py"
+```
+
+Use Glob for file discovery, Grep for content search, Read for full context.
+
+### Map the relevant code
+
+For each significant file, read it fully. Note:
+
+- Key functions and their responsibilities
+- Data flow between components
+- Configuration and environment dependencies
+- Error handling boundaries
+
+## External documentation
+
+### When to look externally
+
+- The codebase uses a library/API and you need to understand its behaviour
+- The user asks about best practices or recommended approaches
+- Internal code references external concepts (protocols, standards, specs)
+
+### How to search
+
+Use `ref_search_documentation` for library/framework docs first — it's faster
+and more targeted than general web search. Fall back to `WebSearch` for broader
+topics or recent information.
+
+Read the actual docs (`ref_read_url` or `WebFetch`) rather than summarising
+from search snippets.
+
+## Present findings
+
+Structure the answer as:
+
+1. **Summary** — one paragraph answering the question directly
+2. **Key findings** — bullet points with file/line references for codebase
+   findings, or doc links for external findings
+3. **Recommendations** (if applicable) — concrete next steps or options with
+   trade-offs
+
+### Rules
+
+- Cite specific files and line numbers for codebase claims: `path/to/file.py:42`
+- Link to docs for external claims
+- Flag uncertainty — say "I didn't find X" rather than guessing
+- Keep it concise. If the user wants more detail on a specific finding, they'll
+  ask
+- Don't suggest code changes unless asked — this is research, not implementation

--- a/claude/skills/review-pr/SKILL.md
+++ b/claude/skills/review-pr/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: review-pr
+description: Read a GitHub PR and walk through review suggestions interactively. Use when asked to review a PR link, understand PR changes, or prepare review comments.
+---
+
+# Review PR
+
+Read a GitHub PR, gather existing reviewer comments, analyse the diff, and walk
+the user through suggestions interactively. **Never post comments on the PR.**
+
+## 1. Fetch PR context
+
+Extract owner, repo, and PR number from the provided link.
+
+```bash
+gh pr view {PR_NUMBER} --repo {OWNER}/{REPO} --json title,body,baseRefName,headRefName,labels
+gh pr diff {PR_NUMBER} --repo {OWNER}/{REPO}
+```
+
+## 2. Fetch existing review comments
+
+```bash
+gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments
+gh pr view {PR_NUMBER} --repo {OWNER}/{REPO} --json reviews,comments
+```
+
+Skip bot comments. For each human comment, note:
+- Who said it
+- What file/line it's on
+- Whether it's resolved or open
+
+## 3. Read changed files in full
+
+For every file with non-trivial changes, read the full file to understand
+surrounding context. Don't review the diff in isolation.
+
+## 4. Analyse
+
+Look for:
+
+1. **Bugs** — logic errors, off-by-ones, null/None handling, race conditions
+2. **Security** — injection, auth gaps, secrets in code
+3. **Design** — wrong abstraction, tight coupling, violation of existing patterns
+4. **Edge cases** — missing error handling at system boundaries
+5. **Clarity** — misleading names, unnecessary complexity
+
+For each existing reviewer comment, understand their reasoning and note whether
+the author has addressed it.
+
+## 5. Present summary
+
+Print a brief summary:
+
+- What the PR does (1-2 sentences)
+- Number of suggestions you have
+- Summary of existing reviewer comments and their status (open/resolved/addressed)
+
+## 6. Walk through suggestions
+
+Step through each suggestion **one at a time**. For each, print:
+
+- **File and line** — `path/to/file.py:42`
+- **Severity** — bug, security, design, edge-case, clarity
+- **The issue** — what's wrong and why it matters
+- **Suggested fix** — concrete recommendation
+- **Existing reviewer context** — if a reviewer already flagged this area,
+  summarise their comment and whether it overlaps
+
+After presenting each suggestion, **pause and wait** for the user. They may:
+- Ask questions about the suggestion
+- Disagree and want to skip it
+- Ask you to draft a comment (but don't post it)
+- Say "next" to move on
+
+Only proceed to the next suggestion when the user is ready.
+
+## Rules
+
+- **Never comment on the PR** — all output stays in this conversation
+- **Never approve or request changes on the PR**
+- Read full files, not just the diff
+- Be direct — state the issue, explain why, suggest a fix
+- If a reviewer already made the same point, say so and don't repeat it
+- When all suggestions are covered, offer to draft all agreed comments as a
+  batch the user can copy-paste or post themselves


### PR DESCRIPTION
## Summary

Three new Claude Code skills for sub-agent workflows:

- **code-review** — reviews code changes (GitHub PRs or local diffs) and posts inline comments with severity levels
- **research** — investigates questions by combining codebase exploration with external documentation lookups, returns structured findings
- **review-pr** — interactive PR walk-through that reads the diff and existing reviewer comments, then steps through suggestions one at a time without ever commenting on the PR

## Test plan

- Invoke `/code-review` against a PR and verify it posts inline comments
- Invoke `/research` with a codebase question and verify it returns cited findings
- Invoke `/review-pr` with a PR link and verify it walks through suggestions interactively without posting to GitHub