### PR TITLE
Add Obsidian MCP, consolidate Claude config, fix commit workflow

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -25,6 +25,12 @@ When working in a particular language, look for a matching skill (e.g. `python-c
 
 Notes are at `/home/iainmclaughlan/notes/hitchhiker/`. Prefer reading notes directly with `Read` or `Grep` over using the Obsidian MCP server — direct reads are cheaper. Only use the MCP when you need fuzzy search across the vault and don't know which file to look in.
 
+## Git commit format
+
+**Never** use `$()` command substitution or HEREDOC for commit messages — this triggers a security confirmation prompt. Instead:
+1. Use the `Write` tool to write the commit message to `/tmp/commit_msg.txt`
+2. Run `git commit -F /tmp/commit_msg.txt`
+
 ## Suggest rule/skill improvements
 
 If a workflow or command fails, suggest adding or updating a skill to handle it correctly next time.

--- a/claude/skills/commit-code/SKILL.md
+++ b/claude/skills/commit-code/SKILL.md
@@ -19,6 +19,15 @@ Pre-commit hooks will run and may modify files. If hooks modify files:
 <Description>
 ```
 
+### How to commit
+
+Write the message to a temp file to avoid command substitution prompts:
+
+1. Use the `Write` tool to write the commit message to `/tmp/commit_msg.txt`
+2. Then run: `git commit -F /tmp/commit_msg.txt`
+
+**Never** use `git commit -m "$(cat <<'EOF' ... EOF)"` — the `$()` substitution triggers a security confirmation prompt.
+
 ### Rules
 
 **Title (first line):**
@@ -39,7 +48,7 @@ Pre-commit hooks will run and may modify files. If hooks modify files:
 When changes have been committed ask if we are ready to push. If we are ready to push, push using:
 
 ```bash
-just push
+git push origin <branch-name>
 ```
 
 If pushing as part of a rebase use


### PR DESCRIPTION
## Summary

- Adds Obsidian vault MCP server to `claude/settings.json` and documents a preference for direct file reads over MCP calls
- Consolidates Claude configuration: removes the `claude/rules/` directory in favour of a leaner `claude/CLAUDE.md` and proper skills
- Migrates `python-coding` from a rules file to a skill, adds `obsidian-note` and `worktree-testing` skills
- Fixes commit workflow to use `git commit -F /tmp/commit_msg.txt` instead of `$()` HEREDOC substitution, which was triggering security confirmation prompts