### PR TITLE
Add monitor-deployment skill and cld alias

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -127,6 +127,7 @@ bindkey '\e[1;5C' forward-word
 # #########
 
 # MISC
+alias cld="claude --dangerously-skip-permissions"
 alias vim="nvim"
 alias vi="nvim"
 alias tm="tmux"


### PR DESCRIPTION
## Summary

- Add `monitor-deployment` skill for monitoring deployments via Claude Code
- Add `cld` zsh alias as shorthand for `claude --dangerously-skip-permissions`