### PR TITLE
Remove zsh profiling tools

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -9,8 +9,6 @@
 # TODO: eza:
 # cargo install eza
 
-zmodload zsh/zprof
-
 # Path to your oh-my-zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
 
@@ -331,5 +329,3 @@ export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 export PATH="/opt/homebrew/opt/postgresql@17/bin:$PATH"
 export PATH="/opt/homebrew/opt/libpq/bin:$PATH"
-
-zprof


### PR DESCRIPTION
Removes the `zmodload zsh/zprof` and `zprof` calls that were added temporarily to diagnose shell startup time. These are no longer needed after the optimisation work in #13.